### PR TITLE
Add an example that shows maps & scores for flying competitions.

### DIFF
--- a/frontend/src/Frontend/Page/Examples.hs
+++ b/frontend/src/Frontend/Page/Examples.hs
@@ -65,4 +65,9 @@ exList =
     , "https://github.com/rvl/flatris"
     , ""
     )
+  , ( "Forbes Flatlands 2018"
+    , "http://2018-forbes.flaretiming.com/"
+    , "https://github.com/BlockScope/flare-timing/tree/master/app-view"
+    , "A hang gliding competition with the longest task"
+    )
   ]


### PR DESCRIPTION
Thanks for the list of examples. I have this one to add. I'm using a reflex-frp web app to show the task, map and scores for hang gliding and paragliding competitions. The specific example I've chosen to link to is Forbes 2018. I flew in this competition in earlier years.

The scores shown are generated with a [series of command line apps](https://flare-timing.readthedocs.io). The aim is to duplicate the [official results](https://www.forbesflatlands.com/results-2018) as scored by [FS](http://fs.fai.org/). The [flare-timing readme](https://github.com/BlockScope/flare-timing#readme) says more about this. It is a work in progress but far enough along that I thought it worthy to include in this list of reflex-frp examples.

FS itself is closed source, a private repo of [FAI-CIVL](https://github.com/FAI-CIVL).